### PR TITLE
fix: flytt hooks call lenger opp i pagegenerator og sectiongenerator

### DIFF
--- a/.changeset/little-jobs-deliver.md
+++ b/.changeset/little-jobs-deliver.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-page-generator": patch
+---
+
+fix: flytt hooks call lenger opp i pagegenerator og sectiongenerator

--- a/src/components/Generate/GenerateComponent.tsx
+++ b/src/components/Generate/GenerateComponent.tsx
@@ -44,12 +44,24 @@ import { PageGeneratorField, PageGeneratorSupportedFields } from '../../types';
 import { ChangeEvent, useContext } from 'react';
 import { SectionGenerator } from '../../components';
 import { PageGeneratorContext } from '../PageGenerator/PageGeneratorContext';
-import { GenerateGridChild } from './GenerateGridChild';
+import {
+  GenerateGridChild,
+  GenerateGridChildProperties,
+} from './GenerateGridChild';
 import '../../styles/page-generator-fieldset.css';
 
-export const GenerateComponent = (index: number, field: PageGeneratorField) => {
-  const { fieldOnChange, selectOnChange, datePickerOnChange, onBlur } =
-    useContext(PageGeneratorContext);
+export const GenerateComponent = (
+  index: number,
+  field: PageGeneratorField,
+  props: GenerateGridChildProperties,
+) => {
+  const {
+    fieldOnChange,
+    selectOnChange,
+    datePickerOnChange,
+    onBlur,
+    screenSize,
+  } = props;
 
   const inputFieldOnChange = (
     event: ChangeEvent<HTMLInputElement & Record<string, never>>,
@@ -58,7 +70,6 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
     event: ChangeEvent<HTMLTextAreaElement & Record<string, never>>,
   ) => fieldOnChange(event);
 
-  const screenSize = useScreenSize();
   const GridStyling = {
     ...getHooksGridStyling(screenSize),
     marginLeft: undefined,
@@ -89,7 +100,7 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
       return (
         <CheckboxGroup {...field.props} key={index}>
           {field.children.map((child, childIndex) => {
-            return !child.hide && GenerateComponent(childIndex, child);
+            return !child.hide && GenerateComponent(childIndex, child, props);
           })}
         </CheckboxGroup>
       );
@@ -105,7 +116,7 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
       return (
         <DescriptionList {...field.props} key={index}>
           {field.children.map((child, childIndex) => {
-            return !child.hide && GenerateComponent(childIndex, child);
+            return !child.hide && GenerateComponent(childIndex, child, props);
           })}
         </DescriptionList>
       );
@@ -113,7 +124,7 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
       return (
         <DescriptionListGroup {...field.props} key={index}>
           {field.children.map((child, childIndex) => {
-            return !child.hide && GenerateComponent(childIndex, child);
+            return !child.hide && GenerateComponent(childIndex, child, props);
           })}
         </DescriptionListGroup>
       );
@@ -141,7 +152,7 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
       return (
         <DrawerGroup {...field.props} key={index}>
           {field.children.map((child, childIndex) => {
-            return !child.hide && GenerateComponent(childIndex, child);
+            return !child.hide && GenerateComponent(childIndex, child, props);
           })}
         </DrawerGroup>
       );
@@ -160,7 +171,11 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
         >
           {field.children.map((child, childIndex) => {
             if ((child as PageGeneratorField).component === 'Legend') {
-              return GenerateComponent(childIndex, child as PageGeneratorField);
+              return GenerateComponent(
+                childIndex,
+                child as PageGeneratorField,
+                props,
+              );
             } else {
               return GenerateGridChild(child, childIndex);
             }
@@ -183,7 +198,7 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
       return (
         <HStack {...field.props} key={index}>
           {field.children.map((child, childIndex) => {
-            return !child.hide && GenerateComponent(childIndex, child);
+            return !child.hide && GenerateComponent(childIndex, child, props);
           })}
         </HStack>
       );
@@ -211,7 +226,7 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
       return (
         <List {...field.props} key={index}>
           {field.children.map((child, childIndex) => {
-            return !child.hide && GenerateComponent(childIndex, child);
+            return !child.hide && GenerateComponent(childIndex, child, props);
           })}
         </List>
       );
@@ -246,7 +261,7 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
       return (
         <RadioButtonGroup {...field.props} key={index}>
           {field.children.map((child, childIndex) => {
-            return !child.hide && GenerateComponent(childIndex, child);
+            return !child.hide && GenerateComponent(childIndex, child, props);
           })}
         </RadioButtonGroup>
       );
@@ -282,7 +297,7 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
       return (
         <ToggleBar {...field.props} key={index}>
           {field.children.map((child, childIndex) => {
-            return !child.hide && GenerateComponent(childIndex, child);
+            return !child.hide && GenerateComponent(childIndex, child, props);
           })}
         </ToggleBar>
       );
@@ -298,7 +313,7 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
       return (
         <ToggleButtonGroup {...field.props} key={index}>
           {field.children.map((child, childIndex) => {
-            return !child.hide && GenerateComponent(childIndex, child);
+            return !child.hide && GenerateComponent(childIndex, child, props);
           })}
         </ToggleButtonGroup>
       );
@@ -326,7 +341,7 @@ export const GenerateComponent = (index: number, field: PageGeneratorField) => {
       return (
         <VStack {...field.props} key={index}>
           {field.children.map((child, childIndex) => {
-            return !child.hide && GenerateComponent(childIndex, child);
+            return !child.hide && GenerateComponent(childIndex, child, props);
           })}
         </VStack>
       );

--- a/src/components/Generate/GenerateGridChild.tsx
+++ b/src/components/Generate/GenerateGridChild.tsx
@@ -1,19 +1,47 @@
-import { GridChild } from '@norges-domstoler/dds-components';
+import {
+  GridChild,
+  ScreenSize,
+  useScreenSize,
+} from '@norges-domstoler/dds-components';
 import { isPageGeneratorRow } from '../../helpers';
 import { PageGeneratorField, PageGeneratorRow } from '../../types';
 import { GenerateComponent } from './GenerateComponent';
 import { GenerateRow } from './GenerateRow';
+import { useContext } from 'react';
+import {
+  PageGeneratorContext,
+  PageGeneratorContextModel,
+} from '../PageGenerator/PageGeneratorContext';
+
+export interface GenerateGridChildProperties {
+  fieldOnChange: PageGeneratorContextModel['fieldOnChange'];
+  selectOnChange: PageGeneratorContextModel['selectOnChange'];
+  datePickerOnChange: PageGeneratorContextModel['datePickerOnChange'];
+  onBlur: PageGeneratorContextModel['onBlur'];
+  screenSize: ScreenSize;
+}
 
 export const GenerateGridChild = (
   obj: PageGeneratorField | PageGeneratorRow,
   index: number,
 ) => {
   const isRow = isPageGeneratorRow(obj);
+  const { fieldOnChange, selectOnChange, datePickerOnChange, onBlur } =
+    useContext(PageGeneratorContext);
+  const screenSize = useScreenSize();
+
+  const props: GenerateGridChildProperties = {
+    fieldOnChange,
+    selectOnChange,
+    datePickerOnChange,
+    onBlur,
+    screenSize,
+  };
   return (
     !obj.hide && (
       <GridChild columnsOccupied="all" key={index}>
-        {isRow && GenerateRow(index, obj.fields)}
-        {!isRow && GenerateComponent(index, obj)}
+        {isRow && GenerateRow(index, obj.fields, props)}
+        {!isRow && GenerateComponent(index, obj, props)}
       </GridChild>
     )
   );

--- a/src/components/Generate/GenerateRow.tsx
+++ b/src/components/Generate/GenerateRow.tsx
@@ -2,17 +2,21 @@ import { HStack, useScreenSize } from '@norges-domstoler/dds-components';
 import { PageGeneratorField } from '../../types';
 import { PageGeneratorTokens } from '../../tokens';
 import { GenerateComponent } from './GenerateComponent';
+import { GenerateGridChildProperties } from './GenerateGridChild';
 
-export const GenerateRow = (index: number, fields: PageGeneratorField[]) => {
-  const screenSize = useScreenSize();
+export const GenerateRow = (
+  index: number,
+  fields: PageGeneratorField[],
+  props: GenerateGridChildProperties,
+) => {
   return (
     <HStack
-      gap={PageGeneratorTokens.Stack[screenSize] || 0}
+      gap={PageGeneratorTokens.Stack[props.screenSize] || 0}
       htmlProps={{ style: { flexWrap: 'wrap' } }}
       key={index}
     >
       {fields.map((field, childIndex) => {
-        return !field.hide && GenerateComponent(childIndex, field);
+        return !field.hide && GenerateComponent(childIndex, field, props);
       })}
     </HStack>
   );

--- a/src/components/PageGenerator/PageGeneratorContext.tsx
+++ b/src/components/PageGenerator/PageGeneratorContext.tsx
@@ -4,7 +4,7 @@ import { SelectOption } from '@norges-domstoler/dds-components';
 import { SingleValue, MultiValue } from 'react-select';
 import { CalendarDate } from '@internationalized/date';
 
-interface PageGeneratorContextModel {
+export interface PageGeneratorContextModel {
   fields: PageGeneratorProps['fields'];
   state: object;
   fieldOnChange: <T extends HTMLInputElement | HTMLTextAreaElement>(

--- a/src/components/SectionGenerator/SectionGenerator.tsx
+++ b/src/components/SectionGenerator/SectionGenerator.tsx
@@ -1,10 +1,15 @@
-import { getBaseHTMLProps } from '@norges-domstoler/dds-components';
+import {
+  getBaseHTMLProps,
+  useScreenSize,
+} from '@norges-domstoler/dds-components';
 import { SectionGeneratorProps } from '../../types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { isSectionGeneratorRow } from '../../helpers';
 import { GenerateRow } from '../Generate/GenerateRow';
 import { GenerateComponent } from '../Generate/GenerateComponent';
 import { PageGeneratorProvider } from '../PageGenerator/PageGeneratorProvider';
+import { PageGeneratorContext } from '../PageGenerator/PageGeneratorContext';
+import { GenerateGridChildProperties } from '../Generate/GenerateGridChild';
 
 /**
  * Generer komponenter fra @norges-domstoler/dds-components, basert på `fields` propertien. SectionGenerator legger på en wrapper, basert på `as` propertien.
@@ -13,6 +18,16 @@ import { PageGeneratorProvider } from '../PageGenerator/PageGeneratorProvider';
 export const SectionGenerator = (props: SectionGeneratorProps) => {
   const { fields = [], stateOnChange, as } = props;
   const { id, className, htmlProps, ...rest } = props;
+  const { fieldOnChange, selectOnChange, datePickerOnChange, onBlur } =
+    useContext(PageGeneratorContext);
+  const screenSize = useScreenSize();
+  const generateGridChildProps: GenerateGridChildProperties = {
+    fieldOnChange,
+    selectOnChange,
+    datePickerOnChange,
+    onBlur,
+    screenSize,
+  };
 
   const Parent = (props: { children: (false | JSX.Element)[] }) => {
     if (as === 'div') {
@@ -41,10 +56,12 @@ export const SectionGenerator = (props: SectionGeneratorProps) => {
           const isRow = isSectionGeneratorRow(obj);
           return (
             !obj.hide && (
-              <>
-                {isRow && GenerateRow(index, obj.fields)}
-                {!isRow && GenerateComponent(index, obj)}
-              </>
+              <React.Fragment key={index}>
+                {isRow &&
+                  GenerateRow(index, obj.fields, generateGridChildProps)}
+                {!isRow &&
+                  GenerateComponent(index, obj, generateGridChildProps)}
+              </React.Fragment>
             )
           );
         })}


### PR DESCRIPTION
Om et felt ble skjult basert på input i skjema, ble det kastet feil på `Rendered fewer hooks than expected`; hooks ble kalt i feil rekkefølge sammenlignet med forrige rendering. Ved å flytte hooks call lenger opp, sørges det for at hooks alltid kalles, uansett om feltet er skjult eller ikke.